### PR TITLE
Fix pokerus to allow evolved untransferrables

### DIFF
--- a/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
@@ -295,7 +295,7 @@ public sealed class MiscVerifier : Verifier
 
         var strain = pk.PokerusStrain;
         var days = pk.PokerusDays;
-        bool strainValid = Pokerus.IsStrainValid(pk, strain, days);
+        bool strainValid = Pokerus.IsStrainValid(pk, data.Info.EncounterMatch, strain, days);
         if (!strainValid)
             data.AddLine(GetInvalid(string.Format(LPokerusStrainUnobtainable_0, strain)));
 

--- a/PKHeX.Core/PKM/Util/EntityDetection.cs
+++ b/PKHeX.Core/PKM/Util/EntityDetection.cs
@@ -20,8 +20,7 @@ public static class EntityDetection
         SIZE_5PARTY or
         SIZE_6STORED or SIZE_6PARTY or
         SIZE_8STORED or SIZE_8PARTY or
-        SIZE_8ASTORED or SIZE_8APARTY or
-        SIZE_9STORED or SIZE_9PARTY
+        SIZE_8ASTORED or SIZE_8APARTY
         ;
 
     public static bool IsPresentGB(ReadOnlySpan<byte> data) => data[0] != 0; // Species non-zero


### PR DESCRIPTION
PLA sneasel -> transfer, catch virus -> PLA, evolve => was flagged. Need to check the encounter species-form, not the current species-form. List all the species-form that are of consideration. Wyrdeer, Kleavor, Ursaluna, Sneasler, Overqwil, Basculegion