### PR TITLE
Fix: Disable CETCompat to prevent crash with deep InitialDirectory (#…

### DIFF
--- a/PKHeX.WinForms/PKHeX.WinForms.csproj
+++ b/PKHeX.WinForms/PKHeX.WinForms.csproj
@@ -7,6 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
+    <CETCompat>false</CETCompat>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
…4481)

Setting CETCompat to false in the project file resolves ntdll.dll crashes observed on .NET 9 Preview when OpenFileDialog's InitialDirectory points to deep paths like MyDocuments. This allows the application to run without triggering CET violations in this specific scenario.

Temporary merge until .NET 10; CETCompat isn't necessarily required for this application so no harm disabling this feature.